### PR TITLE
fix!: additionalProperties false by default

### DIFF
--- a/generator/gen.ts
+++ b/generator/gen.ts
@@ -127,6 +127,7 @@ export default async (params: { files: string[] }) => {
   const settings: TJS.PartialArgs = {
     required: true,
     ref: true,
+    noExtraProps: true,
     aliasRef: false,
     skipLibCheck: true,
     topRef: true,

--- a/tap-snapshots/test/integration.test.ts.test.cjs
+++ b/tap-snapshots/test/integration.test.ts.test.cjs
@@ -45,6 +45,7 @@ Object {
   "Query": Object {},
   "schema": Object {
     "params": Object {
+      "additionalProperties": true,
       "properties": Object {
         "castedToNumber": Object {
           "type": "number",
@@ -128,7 +129,7 @@ Object {
   "Headers": Array [
     "HTTP/1.1 200 OK",
     "content-type: application/json; charset=utf-8",
-    "content-length: 45",
+    "content-length: 59",
     "Date: dateString",
     "Connection: keep-alive",
   ],
@@ -139,6 +140,7 @@ Object {
       },
       Object {
         "id": "1",
+        "type": "TEST",
       },
       Object {
         "any": "thing",
@@ -155,6 +157,7 @@ Array [
   },
   Object {
     "id": "1",
+    "type": "TEST",
   },
   Object {
     "any": "thing",
@@ -205,6 +208,7 @@ Object {
   "Query": Object {},
   "schema": Object {
     "body": Object {
+      "additionalProperties": false,
       "properties": Object {
         "user": Object {
           "$ref": "test_schema#/properties/User",
@@ -217,6 +221,7 @@ Object {
     },
     "response": Object {
       "200": Object {
+        "additionalProperties": false,
         "properties": Object {
           "msg": Object {
             "type": "string",
@@ -280,6 +285,7 @@ Object {
   "Query": Object {},
   "schema": Object {
     "body": Object {
+      "additionalProperties": false,
       "properties": Object {
         "user": Object {
           "$ref": "test_schema#/properties/User",
@@ -292,6 +298,7 @@ Object {
     },
     "response": Object {
       "200": Object {
+        "additionalProperties": false,
         "properties": Object {
           "msg": Object {
             "type": "string",
@@ -355,6 +362,7 @@ Object {
   "Query": Object {},
   "schema": Object {
     "body": Object {
+      "additionalProperties": false,
       "properties": Object {
         "user": Object {
           "$ref": "test_schema#/properties/User",
@@ -367,6 +375,7 @@ Object {
     },
     "response": Object {
       "200": Object {
+        "additionalProperties": false,
         "properties": Object {
           "msg": Object {
             "type": "string",
@@ -420,6 +429,7 @@ Object {
   "Query": Object {},
   "schema": Object {
     "params": Object {
+      "additionalProperties": false,
       "properties": Object {
         "id": Object {
           "type": "number",
@@ -491,6 +501,7 @@ Object {
   "schema": Object {
     "response": Object {
       "200": Object {
+        "additionalProperties": false,
         "properties": Object {
           "frame": Object {
             "$ref": "test_schema#/properties/TestObj",
@@ -511,7 +522,7 @@ Object {
   "Headers": Array [
     "HTTP/1.1 200 OK",
     "content-type: application/json; charset=utf-8",
-    "content-length: 25",
+    "content-length: 39",
     "Date: dateString",
     "Connection: keep-alive",
   ],
@@ -519,6 +530,7 @@ Object {
     Object {
       "frame": Object {
         "id": "string",
+        "type": "TEST",
       },
     },
   ],
@@ -544,6 +556,7 @@ Object {
   "Query": Object {},
   "schema": Object {
     "headers": Object {
+      "additionalProperties": false,
       "properties": Object {
         "authorization": Object {
           "type": "string",
@@ -559,6 +572,7 @@ Object {
       "type": "object",
     },
     "querystring": Object {
+      "additionalProperties": false,
       "properties": Object {
         "getQueryParam": Object {
           "type": "boolean",
@@ -606,6 +620,7 @@ Object {
   },
   "schema": Object {
     "querystring": Object {
+      "additionalProperties": false,
       "properties": Object {
         "match": Object {
           "type": "string",
@@ -618,6 +633,7 @@ Object {
     },
     "response": Object {
       "200": Object {
+        "additionalProperties": false,
         "properties": Object {
           "value": Object {
             "enum": Array [
@@ -701,6 +717,7 @@ Object {
   "Query": Object {},
   "schema": Object {
     "headers": Object {
+      "additionalProperties": false,
       "properties": Object {
         "authorization": Object {
           "type": "string",
@@ -716,6 +733,7 @@ Object {
       "type": "object",
     },
     "querystring": Object {
+      "additionalProperties": false,
       "properties": Object {
         "getQueryParam": Object {
           "type": "boolean",
@@ -794,6 +812,7 @@ Object {
   },
   "schema": Object {
     "headers": Object {
+      "additionalProperties": false,
       "properties": Object {
         "authorization": Object {
           "type": "string",
@@ -809,6 +828,7 @@ Object {
       "type": "object",
     },
     "querystring": Object {
+      "additionalProperties": false,
       "properties": Object {
         "getQueryParam": Object {
           "type": "boolean",
@@ -921,6 +941,7 @@ Object {
   "Query": Object {},
   "schema": Object {
     "headers": Object {
+      "additionalProperties": false,
       "properties": Object {
         "authorization": Object {
           "type": "string",
@@ -936,6 +957,7 @@ Object {
       "type": "object",
     },
     "querystring": Object {
+      "additionalProperties": false,
       "properties": Object {
         "getQueryParam": Object {
           "type": "boolean",
@@ -964,6 +986,7 @@ Object {
   "Query": Object {},
   "schema": Object {
     "headers": Object {
+      "additionalProperties": false,
       "properties": Object {
         "authorization": Object {
           "type": "string",
@@ -979,6 +1002,7 @@ Object {
       "type": "object",
     },
     "querystring": Object {
+      "additionalProperties": false,
       "properties": Object {
         "getQueryParam": Object {
           "type": "boolean",
@@ -1047,6 +1071,7 @@ Object {
   "schema": Object {
     "response": Object {
       "200": Object {
+        "additionalProperties": false,
         "properties": Object {
           "id": Object {
             "type": "string",
@@ -1115,6 +1140,7 @@ Object {
   "Query": Object {},
   "schema": Object {
     "headers": Object {
+      "additionalProperties": false,
       "properties": Object {
         "authorization": Object {
           "type": "string",
@@ -1130,6 +1156,7 @@ Object {
       "type": "object",
     },
     "querystring": Object {
+      "additionalProperties": false,
       "properties": Object {
         "getQueryParam": Object {
           "type": "boolean",
@@ -1152,13 +1179,12 @@ Object {
   "Headers": Object {
     "authorization": "required",
     "getheader": "isHere",
-    "host": "localhost:80",
-    "user-agent": "lightMyRequest",
   },
   "Params": Object {},
   "Query": Object {},
   "schema": Object {
     "headers": Object {
+      "additionalProperties": false,
       "properties": Object {
         "authorization": Object {
           "type": "string",
@@ -1174,6 +1200,7 @@ Object {
       "type": "object",
     },
     "querystring": Object {
+      "additionalProperties": false,
       "properties": Object {
         "getQueryParam": Object {
           "type": "boolean",
@@ -1230,7 +1257,7 @@ Object {
   "Headers": Array [
     "HTTP/1.1 200 OK",
     "content-type: application/json; charset=utf-8",
-    "content-length: 3735",
+    "content-length: 3922",
     "Date: dateString",
     "Connection: keep-alive",
   ],
@@ -1242,6 +1269,7 @@ Object {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "properties": Object {
             "Obj": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "id": Object {
                   "format": "uuid",
@@ -1260,18 +1288,6 @@ Object {
             "ObjectId": Object {
               "type": "string",
             },
-            "Omit__Obj,\\"type\\"__": Object {
-              "properties": Object {
-                "id": Object {
-                  "format": "uuid",
-                  "type": "string",
-                },
-              },
-              "required": Array [
-                "id",
-              ],
-              "type": "object",
-            },
             "RecordStringString": Object {
               "additionalProperties": Object {
                 "anyOf": Array [
@@ -1286,8 +1302,10 @@ Object {
               "type": "object",
             },
             "SharedRequest": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "headers": Object {
+                  "additionalProperties": false,
                   "properties": Object {
                     "authorization": Object {
                       "type": "string",
@@ -1302,19 +1320,25 @@ Object {
               "type": "object",
             },
             "TestObj": Object {
-              "$ref": "#/definitions/def-0/properties/Omit__Obj,%22type%22__",
+              "additionalProperties": false,
               "properties": Object {
+                "id": Object {
+                  "format": "uuid",
+                  "type": "string",
+                },
                 "type": Object {
                   "const": "TEST",
                   "type": "string",
                 },
               },
               "required": Array [
+                "id",
                 "type",
               ],
               "type": "object",
             },
             "User": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "name": Object {
                   "type": "string",
@@ -1401,6 +1425,7 @@ Object {
                 "in": "body",
                 "name": "body",
                 "schema": Object {
+                  "additionalProperties": false,
                   "properties": Object {
                     "user": Object {
                       "$ref": "#/definitions/def-0/properties/User",
@@ -1417,6 +1442,7 @@ Object {
               "200": Object {
                 "description": "Default Response",
                 "schema": Object {
+                  "additionalProperties": false,
                   "properties": Object {
                     "msg": Object {
                       "type": "string",
@@ -1449,6 +1475,7 @@ Object {
               "200": Object {
                 "description": "Default Response",
                 "schema": Object {
+                  "additionalProperties": false,
                   "properties": Object {
                     "value": Object {
                       "enum": Array [
@@ -1505,6 +1532,7 @@ Object {
               "200": Object {
                 "description": "Default Response",
                 "schema": Object {
+                  "additionalProperties": false,
                   "properties": Object {
                     "value": Object {
                       "enum": Array [
@@ -1529,6 +1557,7 @@ Object {
               "200": Object {
                 "description": "Default Response",
                 "schema": Object {
+                  "additionalProperties": false,
                   "properties": Object {
                     "id": Object {
                       "type": "string",
@@ -1573,6 +1602,7 @@ Object {
               "200": Object {
                 "description": "Default Response",
                 "schema": Object {
+                  "additionalProperties": false,
                   "properties": Object {
                     "frame": Object {
                       "$ref": "#/definitions/def-0/properties/TestObj",
@@ -1639,6 +1669,7 @@ Object {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": Object {
         "Obj": Object {
+          "additionalProperties": false,
           "properties": Object {
             "id": Object {
               "format": "uuid",
@@ -1657,18 +1688,6 @@ Object {
         "ObjectId": Object {
           "type": "string",
         },
-        "Omit__Obj,\\"type\\"__": Object {
-          "properties": Object {
-            "id": Object {
-              "format": "uuid",
-              "type": "string",
-            },
-          },
-          "required": Array [
-            "id",
-          ],
-          "type": "object",
-        },
         "RecordStringString": Object {
           "additionalProperties": Object {
             "anyOf": Array [
@@ -1683,8 +1702,10 @@ Object {
           "type": "object",
         },
         "SharedRequest": Object {
+          "additionalProperties": false,
           "properties": Object {
             "headers": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "authorization": Object {
                   "type": "string",
@@ -1699,19 +1720,25 @@ Object {
           "type": "object",
         },
         "TestObj": Object {
-          "$ref": "#/definitions/def-0/properties/Omit__Obj,%22type%22__",
+          "additionalProperties": false,
           "properties": Object {
+            "id": Object {
+              "format": "uuid",
+              "type": "string",
+            },
             "type": Object {
               "const": "TEST",
               "type": "string",
             },
           },
           "required": Array [
+            "id",
             "type",
           ],
           "type": "object",
         },
         "User": Object {
+          "additionalProperties": false,
           "properties": Object {
             "name": Object {
               "type": "string",
@@ -1798,6 +1825,7 @@ Object {
             "in": "body",
             "name": "body",
             "schema": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "user": Object {
                   "$ref": "#/definitions/def-0/properties/User",
@@ -1814,6 +1842,7 @@ Object {
           "200": Object {
             "description": "Default Response",
             "schema": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "msg": Object {
                   "type": "string",
@@ -1846,6 +1875,7 @@ Object {
           "200": Object {
             "description": "Default Response",
             "schema": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "value": Object {
                   "enum": Array [
@@ -1902,6 +1932,7 @@ Object {
           "200": Object {
             "description": "Default Response",
             "schema": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "value": Object {
                   "enum": Array [
@@ -1926,6 +1957,7 @@ Object {
           "200": Object {
             "description": "Default Response",
             "schema": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "id": Object {
                   "type": "string",
@@ -1970,6 +2002,7 @@ Object {
           "200": Object {
             "description": "Default Response",
             "schema": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "frame": Object {
                   "$ref": "#/definitions/def-0/properties/TestObj",
@@ -2039,6 +2072,7 @@ Object {
   },
   "schema": Object {
     "querystring": Object {
+      "additionalProperties": false,
       "properties": Object {
         "reply": Object {
           "type": "string",
@@ -2051,6 +2085,7 @@ Object {
     },
     "response": Object {
       "200": Object {
+        "additionalProperties": false,
         "properties": Object {
           "value": Object {
             "const": "known",
@@ -2080,6 +2115,7 @@ Object {
   },
   "schema": Object {
     "querystring": Object {
+      "additionalProperties": false,
       "properties": Object {
         "reply": Object {
           "type": "string",
@@ -2092,6 +2128,7 @@ Object {
     },
     "response": Object {
       "200": Object {
+        "additionalProperties": false,
         "properties": Object {
           "value": Object {
             "const": "known",
@@ -2155,6 +2192,7 @@ Object {
   },
   "schema": Object {
     "querystring": Object {
+      "additionalProperties": false,
       "properties": Object {
         "match": Object {
           "type": "string",
@@ -2167,6 +2205,7 @@ Object {
     },
     "response": Object {
       "200": Object {
+        "additionalProperties": false,
         "properties": Object {
           "value": Object {
             "enum": Array [

--- a/test/test_schema.gen.json
+++ b/test/test_schema.gen.json
@@ -8,9 +8,11 @@
         "required": [
           "headers"
         ],
+        "additionalProperties": false,
         "properties": {
           "headers": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "authorization": {
                 "type": "string"
@@ -24,6 +26,7 @@
         "required": [
           "name"
         ],
+        "additionalProperties": false,
         "properties": {
           "name": {
             "type": "string"
@@ -36,6 +39,7 @@
           "id",
           "type"
         ],
+        "additionalProperties": false,
         "properties": {
           "type": {
             "type": "string"
@@ -51,11 +55,16 @@
       },
       "TestObj": {
         "type": "object",
-        "$ref": "test_schema#/properties/Omit__Obj,\"type\"__",
         "required": [
+          "id",
           "type"
         ],
+        "additionalProperties": false,
         "properties": {
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
           "type": {
             "type": "string",
             "const": "TEST"
@@ -102,18 +111,6 @@
             }
           }
         ]
-      },
-      "Omit__Obj,\"type\"__": {
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "id": {
-            "format": "uuid",
-            "type": "string"
-          }
-        }
       }
     },
     "type": "object"
@@ -121,15 +118,16 @@
   "fastify": {
     "GET /": {
       "request": {
-        "$ref": "test_schema#/properties/SharedRequest",
         "type": "object",
         "required": [
           "headers",
           "querystring"
         ],
+        "additionalProperties": false,
         "properties": {
           "querystring": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "getQueryParam": {
                 "type": "boolean"
@@ -142,6 +140,7 @@
               "authorization",
               "getHeader"
             ],
+            "additionalProperties": false,
             "properties": {
               "authorization": {
                 "type": "string"
@@ -198,12 +197,14 @@
         "required": [
           "body"
         ],
+        "additionalProperties": false,
         "properties": {
           "body": {
             "type": "object",
             "required": [
               "user"
             ],
+            "additionalProperties": false,
             "properties": {
               "user": {
                 "$ref": "test_schema#/properties/User"
@@ -219,6 +220,7 @@
             "msg",
             "user"
           ],
+          "additionalProperties": false,
           "properties": {
             "user": {
               "$ref": "test_schema#/properties/User"
@@ -244,6 +246,7 @@
         "required": [
           "params"
         ],
+        "additionalProperties": false,
         "properties": {
           "params": {
             "type": "object",
@@ -251,6 +254,7 @@
               "id",
               "subid"
             ],
+            "additionalProperties": false,
             "properties": {
               "id": {
                 "type": "number"
@@ -272,6 +276,7 @@
           "required": [
             "frame"
           ],
+          "additionalProperties": false,
           "properties": {
             "frame": {
               "$ref": "test_schema#/properties/TestObj"
@@ -286,12 +291,14 @@
         "required": [
           "params"
         ],
+        "additionalProperties": false,
         "properties": {
           "params": {
             "type": "object",
             "required": [
               "castedToNumber"
             ],
+            "additionalProperties": true,
             "properties": {
               "castedToNumber": {
                 "type": "number"
@@ -312,12 +319,14 @@
         "required": [
           "querystring"
         ],
+        "additionalProperties": false,
         "properties": {
           "querystring": {
             "type": "object",
             "required": [
               "match"
             ],
+            "additionalProperties": false,
             "properties": {
               "match": {
                 "type": "string"
@@ -332,6 +341,7 @@
           "required": [
             "value"
           ],
+          "additionalProperties": false,
           "properties": {
             "value": {
               "enum": [
@@ -350,12 +360,14 @@
         "required": [
           "querystring"
         ],
+        "additionalProperties": false,
         "properties": {
           "querystring": {
             "type": "object",
             "required": [
               "reply"
             ],
+            "additionalProperties": false,
             "properties": {
               "reply": {
                 "type": "string"
@@ -370,6 +382,7 @@
           "required": [
             "value"
           ],
+          "additionalProperties": false,
           "properties": {
             "value": {
               "type": "string",
@@ -387,6 +400,7 @@
           "required": [
             "id"
           ],
+          "additionalProperties": false,
           "properties": {
             "id": {
               "type": "string"
@@ -396,5 +410,5 @@
       }
     }
   },
-  "$hash": "55f23702a95be2a6d63340bde05157e37feed81b4eeb0badfccc120a27d59da5__v1.2.0"
+  "$hash": "8ab003f270111590ba01112e01c4a7a46d7f515f36297484e9777ea64bd4b0b2__v1.2.0"
 }

--- a/test/test_schema.ts
+++ b/test/test_schema.ts
@@ -103,6 +103,7 @@ export interface TestSchema extends Schema {
     };
     'GET /inferredParams/:id/:castedToNumber': {
       request: {
+        /** @additionalProperties true */
         params: {
           castedToNumber: number;
         };


### PR DESCRIPTION
Breaking change, erases untyped properties during validation stage in fastify

- see [default fastify AJV options](https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/#validator-compiler)
- see [removeAddtitional in AJV](https://ajv.js.org/options.html#removeadditional)

This would set `additionalProperties: false` in generated schemas to ensure extra properties are erased in payloads, which should be defined with `{[k:string]: type}` for strictness sake anyways