### PR TITLE
Better support for json-like input and outputs in the schema

### DIFF
--- a/generator/gen.ts
+++ b/generator/gen.ts
@@ -124,15 +124,20 @@ export default async (params: { files: string[] }) => {
   };
 
   const PLACEHOLDER_ID = '@__PLACEHOLDER_ID__@' + Date.now();
+  const defaultAgs = TJS.getDefaultArgs();
+
   const settings: TJS.PartialArgs = {
     required: true,
     ref: true,
+    noExtraProps: true,
     aliasRef: false,
     skipLibCheck: true,
     topRef: true,
     ignoreErrors: true,
     strictNullChecks: true,
     id: PLACEHOLDER_ID,
+    // add support for ajv-keywords
+    validationKeywords: [...defaultAgs.validationKeywords, 'instanceof', 'typeof'],
   };
 
   let { files } = params;

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "pretest": "tsnd generator/gen.bin.ts gen 'test/test_schema.ts'",
     "server": "pnpm preserver && tsnd test/server.ts",
     "test": "pnpm pretest && pnpm test:types && pnpm test:integration",
-    "test:integration": "TAP_TS=1 tap test/*.test.ts -R terse",
+    "test:integration": "TAP_TS=1 tap test/*.test.ts -R dot",
     "test:types": "tsc -p test/tsconfig.test.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "glob": "^10.3.4",
     "json-schema-merge-allof": "^0.8.1",
     "json-schema-traverse": "^1.0.0",
+    "type-fest": "^4.6.0",
     "typescript-json-schema": "^0.61.0",
     "yargs": "^17.7.2"
   },
@@ -26,6 +27,8 @@
     "@types/split2": "^4.2.0",
     "@types/tap": "^15.0.9",
     "@types/yargs": "^17.0.24",
+    "ajv-formats": "2.1.1",
+    "ajv-keywords": "5.1.0",
     "coveralls": "3.1.1",
     "fastify": "^4.23.2",
     "husky": "^8.0.3",
@@ -38,7 +41,6 @@
     "tap": "^16.3.8",
     "ts-node-dev": "^2.0.0",
     "tsd": "^0.29.0",
-    "type-fest": "^4.3.1",
     "typescript": "^5.2.2"
   },
   "directories": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   json-schema-traverse:
     specifier: ^1.0.0
     version: 1.0.0
+  type-fest:
+    specifier: ^4.6.0
+    version: 4.6.0
   typescript-json-schema:
     specifier: ^0.61.0
     version: 0.61.0
@@ -58,6 +61,12 @@ devDependencies:
   '@types/yargs':
     specifier: ^17.0.24
     version: 17.0.24
+  ajv-formats:
+    specifier: 2.1.1
+    version: 2.1.1(ajv@8.12.0)
+  ajv-keywords:
+    specifier: 5.1.0
+    version: 5.1.0(ajv@8.12.0)
   coveralls:
     specifier: 3.1.1
     version: 3.1.1
@@ -94,9 +103,6 @@ devDependencies:
   tsd:
     specifier: ^0.29.0
     version: 0.29.0
-  type-fest:
-    specifier: ^4.3.1
-    version: 4.3.1
   typescript:
     specifier: ^5.2.2
     version: 5.2.2
@@ -687,6 +693,15 @@ packages:
         optional: true
     dependencies:
       ajv: 8.12.0
+    dev: true
+
+  /ajv-keywords@5.1.0(ajv@8.12.0):
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
+    dependencies:
+      ajv: 8.12.0
+      fast-deep-equal: 3.1.3
     dev: true
 
   /ajv@6.12.6:
@@ -3617,10 +3632,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /type-fest@4.3.1:
-    resolution: {integrity: sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==}
+  /type-fest@4.6.0:
+    resolution: {integrity: sha512-rLjWJzQFOq4xw7MgJrCZ6T1jIOvvYElXT12r+y0CC6u67hegDHaxcPqb2fZHOGlqxugGQPNB1EnTezjBetkwkw==}
     engines: {node: '>=16'}
-    dev: true
+    dev: false
 
   /typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -6,6 +6,7 @@ import type { Stream } from 'stream';
 export type StatusCode =
     | 100 | '100' // Continue
     | 101 | '101' // Switching Protocols
+    | 103 | '103' // Early Hints
     | 200 | '200' // OK
     | 201 | '201' // Created
     | 202 | '202' // Accepted
@@ -13,6 +14,9 @@ export type StatusCode =
     | 204 | '204' // No Content
     | 205 | '205' // Reset Content
     | 206 | '206' // Partial Content
+    | 207 | '207' // Multi-Status
+    | 208 | '208' // Already Reported
+    | 226 | '226' // IM Used
     | 300 | '300' // Multiple Choices
     | 301 | '301' // Moved Permanently
     | 302 | '302' // Found
@@ -20,6 +24,7 @@ export type StatusCode =
     | 304 | '304' // Not Modified
     | 305 | '305' // Use Proxy
     | 307 | '307' // Temporary Redirect
+    | 308 | '308' // Permanent Redirect
     | 400 | '400' // Bad Request
     | 401 | '401' // Unauthorized
     | 402 | '402' // Payment Required
@@ -39,12 +44,22 @@ export type StatusCode =
     | 416 | '416' // Range Not Satisfiable
     | 417 | '417' // Expectation Failed
     | 426 | '426' // Upgrade Required
+    | 427 | '427' // Unassigned
+    | 428 | '428' // Precondition Required
+    | 429 | '429' // Too Many Requests
+    | 431 | '431' // Request Header Fields Too Large
+    | 451 | '451' // Unavailable For Legal Reasons
     | 500 | '500' // Internal Server Error
     | 501 | '501' // Not Implemented
     | 502 | '502' // Bad Gateway
     | 503 | '503' // Service Unavailable
     | 504 | '504' // Gateway Timeout
-    | 505 | '505'; // HTTP Version Not Supported;
+    | 505 | '505' // HTTP Version Not Supported;
+    | 506 | '506' // Variant Also Negotiates
+    | 507 | '507' // Insufficient Storage
+    | 508 | '508' // Loop Detected
+    | 510 | '510' // Not Extended
+    | 511 | '511' // Network Authentication Required
 
 export interface FastifyError extends Error {
   code: string;
@@ -71,7 +86,8 @@ export interface Operation {
     };
   };
 }
+
 export interface Schema<SecurityId extends string = string> {
   readonly __SCHEMA_TAG__?: 'BETTER-FASTIFY-SCHEMA';
-  paths: Record<`${HTTPMethods} ${string}`, Partial<Operation>>;
+  paths: Record<`${HTTPMethods} ${string}`, Operation>;
 }

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -20,7 +20,7 @@ type NotJsonable = ((...arguments_: any[]) => any) | undefined | symbol | RegExp
 
 type NeverToNull<T> = IsNever<T> extends true ? null : T;
 
-type JsonCastBehavior = 'cast' | 'no-cast';
+type JsonCastBehavior = 'cast' | 'combine';
 
 // Handles tuples and arrays
 type JsonlikeList<T extends unknown[], DoNotCastToPrimitive extends JsonCastBehavior> = T extends []
@@ -43,8 +43,8 @@ export type Jsonlike<T, CastBehavior extends JsonCastBehavior> = T extends Posit
       toJSON(): infer J;
     }
   ? (() => J) extends () => JsonValue // Is J assignable to JsonValue?
-    ? CastBehavior extends 'no-cast'
-      ? T
+    ? CastBehavior extends 'combine'
+      ? T | J
       : J // Then T is Jsonable and its Jsonable value is J
     : Jsonlike<J, CastBehavior> // Maybe if we look a level deeper we'll find a JsonValue
   : // Instanced primitives are objects

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -1,0 +1,60 @@
+import { PositiveInfinity, NegativeInfinity } from 'type-fest/source/numeric';
+import { JsonPrimitive, JsonValue } from 'type-fest/source/basic';
+import { EmptyObject } from 'type-fest/source/empty-object';
+import { TypedArray } from 'type-fest/source/typed-array';
+import { JsonifyList } from 'type-fest/source/jsonify';
+import { WritableDeep } from 'type-fest/source/writable-deep';
+
+export type Id<T> = T extends infer U ? { [K in keyof U]: U[K] } : never;
+export type Get<T, P> = P extends keyof T ? T[P] : never;
+export type Get2<T, P, P2> = Get<Get<T, P>, P2>;
+export type IsEqual<T, U> = (<G>() => G extends T ? 1 : 2) extends <G>() => G extends U ? 1 : 2 ? true : false;
+
+type IsNotJsonableError<T> = Invalid<`${Extract<T, string>} is not Json-like`> & {};
+
+type NotJsonable = ((...arguments_: any[]) => any) | undefined | symbol | RegExp | Function;
+
+// tweaked version of Jsonify from type-fest
+export type Jsonlike<T, DoNotCastToPrimitive extends boolean = false> = T extends PositiveInfinity | NegativeInfinity
+  ? null
+  : T extends NotJsonable
+  ? IsNotJsonableError<'Passed value'>
+  : T extends JsonPrimitive
+  ? T
+  : // Any object with toJSON is special case
+  T extends {
+      toJSON(): infer J;
+    }
+  ? (() => J) extends () => JsonValue // Is J assignable to JsonValue?
+    ? DoNotCastToPrimitive extends true
+      ? T
+      : J // Then T is Jsonable and its Jsonable value is J
+    : Jsonlike<J, DoNotCastToPrimitive> // Maybe if we look a level deeper we'll find a JsonValue
+  : // Instanced primitives are objects
+  T extends Number
+  ? number
+  : T extends String
+  ? string
+  : T extends Boolean
+  ? boolean
+  : T extends Map<any, any> | Set<any>
+  ? EmptyObject
+  : T extends TypedArray
+  ? Record<string, number> // Non-JSONable type union was found not empty
+  : T extends []
+  ? []
+  : T extends unknown[]
+  ? JsonifyList<T>
+  : T extends readonly unknown[]
+  ? JsonifyList<WritableDeep<T>>
+  : T extends object
+  ? {
+      [K in keyof T]: [T[K]] extends [NotJsonable] | [never]
+        ? IsNotJsonableError<K>
+        : Jsonlike<T[K], DoNotCastToPrimitive>;
+    } // JsonifyObject recursive call for its children
+  : IsNotJsonableError<'Passed value'>;
+
+export interface Invalid<msg = any> {
+  readonly __INVALID__: unique symbol;
+}

--- a/src/typed-fastify.ts
+++ b/src/typed-fastify.ts
@@ -1,4 +1,5 @@
 import type * as F from 'fastify';
+import type { Jsonify } from 'type-fest';
 import { RouteGenericInterface } from 'fastify/types/route';
 import { RequestRouteOptions } from 'fastify/types/request';
 
@@ -224,7 +225,7 @@ interface Reply<
         ]
       : [Get2<Op['response'], Status, 'content'>] extends [never]
       ? []
-      : [Get2<Op['response'], Status, 'content'>]
+      : [Get2<Op['response'], Status, 'content'> | Jsonify<Get2<Op['response'], Status, 'content'>>]
   ): AsReply;
 
   readonly request: Request<ServiceSchema, Op, Path, RawServer, RawRequest>;

--- a/src/typed-fastify.ts
+++ b/src/typed-fastify.ts
@@ -350,7 +350,7 @@ interface Request<
   readonly operationPath: Path;
   readonly method: ROptions['method'];
   // A payload within a GET request message has no defined semantics; sending a payload body on a GET request might cause some existing implementations to reject the request.
-  readonly body: ROptions['method'] extends 'GET' ? never : Get<Op['request'], 'body'>;
+  readonly body: ROptions['method'] extends 'GET' ? never : Jsonify<Get<Op['request'], 'body'>>;
   readonly routeOptions: Id<Readonly<ROptions>>;
   readonly routerMethod: ROptions['method'];
   readonly headers: Get<Op['request'], 'headers'>;

--- a/src/typed-fastify.ts
+++ b/src/typed-fastify.ts
@@ -225,7 +225,7 @@ interface Reply<
         ]
       : [Get2<Op['response'], Status, 'content'>] extends [never]
       ? []
-      : [Jsonlike<Get2<Op['response'], Status, 'content'>, true>]
+      : [Jsonlike<Get2<Op['response'], Status, 'content'>, 'no-cast'>]
   ): AsReply;
 
   readonly request: Request<ServiceSchema, Op, Path, RawServer, RawRequest>;
@@ -345,7 +345,7 @@ interface Request<
   readonly operationPath: Path;
   readonly method: ROptions['method'];
   // A payload within a GET request message has no defined semantics; sending a payload body on a GET request might cause some existing implementations to reject the request.
-  readonly body: ROptions['method'] extends 'GET' ? never : Jsonlike<ROptions['body']>;
+  readonly body: ROptions['method'] extends 'GET' ? never : Jsonlike<ROptions['body'], 'cast'>;
   readonly routeOptions: Id<Readonly<ROptions>>;
   readonly routerMethod: ROptions['method'];
   readonly headers: Get<Op['request'], 'headers'>;

--- a/src/typed-fastify.ts
+++ b/src/typed-fastify.ts
@@ -225,7 +225,7 @@ interface Reply<
         ]
       : [Get2<Op['response'], Status, 'content'>] extends [never]
       ? []
-      : [Jsonlike<Get2<Op['response'], Status, 'content'>, 'no-cast'>]
+      : [Jsonlike<Get2<Op['response'], Status, 'content'>, 'combine'>]
   ): AsReply;
 
   readonly request: Request<ServiceSchema, Op, Path, RawServer, RawRequest>;

--- a/tap-snapshots/test/integration.test.ts.test.cjs
+++ b/tap-snapshots/test/integration.test.ts.test.cjs
@@ -1230,7 +1230,7 @@ Object {
   "Headers": Array [
     "HTTP/1.1 200 OK",
     "content-type: application/json; charset=utf-8",
-    "content-length: 3735",
+    "content-length: 4071",
     "Date: dateString",
     "Connection: keep-alive",
   ],
@@ -1486,6 +1486,45 @@ Object {
                 "description": "Default Response",
                 "schema": Object {
                   "type": "string",
+                },
+              },
+            },
+          },
+        },
+        "/jsonify": Object {
+          "post": Object {
+            "parameters": Array [
+              Object {
+                "in": "body",
+                "name": "body",
+                "schema": Object {
+                  "properties": Object {
+                    "date": Object {
+                      "format": "date-time",
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "date",
+                  ],
+                  "type": "object",
+                },
+              },
+            ],
+            "responses": Object {
+              "200": Object {
+                "description": "Default Response",
+                "schema": Object {
+                  "properties": Object {
+                    "date": Object {
+                      "format": "date-time",
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "date",
+                  ],
+                  "type": "object",
                 },
               },
             },
@@ -1883,6 +1922,45 @@ Object {
             "description": "Default Response",
             "schema": Object {
               "type": "string",
+            },
+          },
+        },
+      },
+    },
+    "/jsonify": Object {
+      "post": Object {
+        "parameters": Array [
+          Object {
+            "in": "body",
+            "name": "body",
+            "schema": Object {
+              "properties": Object {
+                "date": Object {
+                  "format": "date-time",
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "date",
+              ],
+              "type": "object",
+            },
+          },
+        ],
+        "responses": Object {
+          "200": Object {
+            "description": "Default Response",
+            "schema": Object {
+              "properties": Object {
+                "date": Object {
+                  "format": "date-time",
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "date",
+              ],
+              "type": "object",
             },
           },
         },

--- a/tap-snapshots/test/integration.test.ts.test.cjs
+++ b/tap-snapshots/test/integration.test.ts.test.cjs
@@ -1099,7 +1099,6 @@ Object {
           },
           "dateString": Object {
             "format": "date-time",
-            "maxLength": 5,
             "type": "string",
           },
           "regexpType": Object {
@@ -1182,7 +1181,6 @@ Object {
           },
           "dateString": Object {
             "format": "date-time",
-            "maxLength": 5,
             "type": "string",
           },
           "regexpType": Object {
@@ -1423,7 +1421,7 @@ Object {
   "Headers": Array [
     "HTTP/1.1 200 OK",
     "content-type: application/json; charset=utf-8",
-    "content-length: 4524",
+    "content-length: 4510",
     "Date: dateString",
     "Connection: keep-alive",
   ],
@@ -1722,7 +1720,6 @@ Object {
                     },
                     "dateString": Object {
                       "format": "date-time",
-                      "maxLength": 5,
                       "type": "string",
                     },
                     "regexpType": Object {
@@ -2182,7 +2179,6 @@ Object {
                 },
                 "dateString": Object {
                   "format": "date-time",
-                  "maxLength": 5,
                   "type": "string",
                 },
                 "regexpType": Object {

--- a/tap-snapshots/test/integration.test.ts.test.cjs
+++ b/tap-snapshots/test/integration.test.ts.test.cjs
@@ -1063,7 +1063,7 @@ exports[`test/integration.test.ts TAP it works with /jsonify > request path:POST
 Object {
   "Body": undefined,
   "Headers": Object {
-    "content-length": "35",
+    "content-length": "53",
     "content-type": "application/json",
     "host": "localhost:80",
     "user-agent": "lightMyRequest",
@@ -1078,9 +1078,14 @@ Object {
           "format": "date-time",
           "type": "string",
         },
+        "regexp": Object {
+          "format": "regex",
+          "type": "string",
+        },
       },
       "required": Array [
         "date",
+        "regexp",
       ],
       "type": "object",
     },
@@ -1092,9 +1097,17 @@ Object {
             "format": "date-time",
             "type": "string",
           },
+          "regexpType": Object {
+            "type": "string",
+          },
+          "type": Object {
+            "type": "string",
+          },
         },
         "required": Array [
           "date",
+          "regexpType",
+          "type",
         ],
         "type": "object",
       },
@@ -1108,13 +1121,15 @@ Object {
   "Headers": Array [
     "HTTP/1.1 200 OK",
     "content-type: application/json; charset=utf-8",
-    "content-length: 35",
+    "content-length: 73",
     "Date: dateString",
     "Connection: keep-alive",
   ],
   "Payload": Array [
     Object {
-      "date": "2023-10-28T13:31:57.949Z",
+      "date": "1970-01-01T00:00:00.000Z",
+      "regexpType": "string",
+      "type": "string",
     },
   ],
 }
@@ -1318,7 +1333,7 @@ Object {
   "Headers": Array [
     "HTTP/1.1 200 OK",
     "content-type: application/json; charset=utf-8",
-    "content-length: 4316",
+    "content-length: 4445",
     "Date: dateString",
     "Connection: keep-alive",
   ],
@@ -1592,9 +1607,14 @@ Object {
                       "format": "date-time",
                       "type": "string",
                     },
+                    "regexp": Object {
+                      "format": "regex",
+                      "type": "string",
+                    },
                   },
                   "required": Array [
                     "date",
+                    "regexp",
                   ],
                   "type": "object",
                 },
@@ -1610,9 +1630,17 @@ Object {
                       "format": "date-time",
                       "type": "string",
                     },
+                    "regexpType": Object {
+                      "type": "string",
+                    },
+                    "type": Object {
+                      "type": "string",
+                    },
                   },
                   "required": Array [
                     "date",
+                    "regexpType",
+                    "type",
                   ],
                   "type": "object",
                 },
@@ -2033,9 +2061,14 @@ Object {
                   "format": "date-time",
                   "type": "string",
                 },
+                "regexp": Object {
+                  "format": "regex",
+                  "type": "string",
+                },
               },
               "required": Array [
                 "date",
+                "regexp",
               ],
               "type": "object",
             },
@@ -2051,9 +2084,17 @@ Object {
                   "format": "date-time",
                   "type": "string",
                 },
+                "regexpType": Object {
+                  "type": "string",
+                },
+                "type": Object {
+                  "type": "string",
+                },
               },
               "required": Array [
                 "date",
+                "regexpType",
+                "type",
               ],
               "type": "object",
             },

--- a/tap-snapshots/test/integration.test.ts.test.cjs
+++ b/tap-snapshots/test/integration.test.ts.test.cjs
@@ -1059,6 +1059,82 @@ Object {
 }
 `
 
+exports[`test/integration.test.ts TAP it works with /jsonify 2 > request path:POST /jsonify id:req-1 1`] = `
+Object {
+  "Body": undefined,
+  "Headers": Object {
+    "content-length": "47",
+    "content-type": "application/json",
+    "host": "localhost:80",
+    "user-agent": "lightMyRequest",
+  },
+  "Params": Object {},
+  "Query": Object {},
+  "schema": Object {
+    "body": Object {
+      "additionalProperties": false,
+      "properties": Object {
+        "date": Object {
+          "format": "date-time",
+          "type": "string",
+        },
+        "regexp": Object {
+          "format": "regex",
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "date",
+        "regexp",
+      ],
+      "type": "object",
+    },
+    "response": Object {
+      "200": Object {
+        "additionalProperties": false,
+        "properties": Object {
+          "date": Object {
+            "format": "date-time",
+            "type": "string",
+          },
+          "regexpType": Object {
+            "type": "string",
+          },
+          "type": Object {
+            "type": "string",
+          },
+        },
+        "required": Array [
+          "date",
+          "regexpType",
+          "type",
+        ],
+        "type": "object",
+      },
+    },
+  },
+}
+`
+
+exports[`test/integration.test.ts TAP it works with /jsonify 2 > response path:POST /jsonify id:req-1 1`] = `
+Object {
+  "Headers": Array [
+    "HTTP/1.1 200 OK",
+    "content-type: application/json; charset=utf-8",
+    "content-length: 73",
+    "Date: dateString",
+    "Connection: keep-alive",
+  ],
+  "Payload": Array [
+    Object {
+      "date": "1970-01-01T00:00:00.000Z",
+      "regexpType": "string",
+      "type": "string",
+    },
+  ],
+}
+`
+
 exports[`test/integration.test.ts TAP it works with /jsonify > request path:POST /jsonify id:req-1 1`] = `
 Object {
   "Body": undefined,

--- a/tap-snapshots/test/integration.test.ts.test.cjs
+++ b/tap-snapshots/test/integration.test.ts.test.cjs
@@ -1097,6 +1097,11 @@ Object {
             "format": "date-time",
             "type": "string",
           },
+          "dateString": Object {
+            "format": "date-time",
+            "maxLength": 5,
+            "type": "string",
+          },
           "regexpType": Object {
             "type": "string",
           },
@@ -1106,6 +1111,7 @@ Object {
         },
         "required": Array [
           "date",
+          "dateString",
           "regexpType",
           "type",
         ],
@@ -1121,13 +1127,14 @@ Object {
   "Headers": Array [
     "HTTP/1.1 200 OK",
     "content-type: application/json; charset=utf-8",
-    "content-length: 73",
+    "content-length: 104",
     "Date: dateString",
     "Connection: keep-alive",
   ],
   "Payload": Array [
     Object {
       "date": "1970-01-01T00:00:00.000Z",
+      "dateString": "Thu Jan 01 1970",
       "regexpType": "string",
       "type": "string",
     },
@@ -1173,6 +1180,11 @@ Object {
             "format": "date-time",
             "type": "string",
           },
+          "dateString": Object {
+            "format": "date-time",
+            "maxLength": 5,
+            "type": "string",
+          },
           "regexpType": Object {
             "type": "string",
           },
@@ -1182,6 +1194,7 @@ Object {
         },
         "required": Array [
           "date",
+          "dateString",
           "regexpType",
           "type",
         ],
@@ -1197,13 +1210,14 @@ Object {
   "Headers": Array [
     "HTTP/1.1 200 OK",
     "content-type: application/json; charset=utf-8",
-    "content-length: 73",
+    "content-length: 104",
     "Date: dateString",
     "Connection: keep-alive",
   ],
   "Payload": Array [
     Object {
       "date": "1970-01-01T00:00:00.000Z",
+      "dateString": "Thu Jan 01 1970",
       "regexpType": "string",
       "type": "string",
     },
@@ -1409,7 +1423,7 @@ Object {
   "Headers": Array [
     "HTTP/1.1 200 OK",
     "content-type: application/json; charset=utf-8",
-    "content-length: 4445",
+    "content-length: 4524",
     "Date: dateString",
     "Connection: keep-alive",
   ],
@@ -1706,6 +1720,11 @@ Object {
                       "format": "date-time",
                       "type": "string",
                     },
+                    "dateString": Object {
+                      "format": "date-time",
+                      "maxLength": 5,
+                      "type": "string",
+                    },
                     "regexpType": Object {
                       "type": "string",
                     },
@@ -1715,6 +1734,7 @@ Object {
                   },
                   "required": Array [
                     "date",
+                    "dateString",
                     "regexpType",
                     "type",
                   ],
@@ -2160,6 +2180,11 @@ Object {
                   "format": "date-time",
                   "type": "string",
                 },
+                "dateString": Object {
+                  "format": "date-time",
+                  "maxLength": 5,
+                  "type": "string",
+                },
                 "regexpType": Object {
                   "type": "string",
                 },
@@ -2169,6 +2194,7 @@ Object {
               },
               "required": Array [
                 "date",
+                "dateString",
                 "regexpType",
                 "type",
               ],

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -28,6 +28,10 @@ export const defaultService: Service<TestSchema> = {
   'GET /user_and_obj': (req, reply) => {
     return reply.status(200).send([{ name: 'user1' }, { id: '1', type: 'TEST' }, { any: 'thing' }]);
   },
+  'POST /jsonify': (req, reply) => {
+    const { date } = req.body;
+    return reply.status(200).send({ date: date.toJSON() });
+  },
   'POST /': (req, reply) => {
     if (req.operationPath !== 'POST /') {
       throw new Error('Should never happen');

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -30,7 +30,8 @@ export const defaultService: Service<TestSchema> = {
   },
   'POST /jsonify': (req, reply) => {
     const { date } = req.body;
-    return reply.status(200).send({ date: date.toJSON() });
+    date.charAt; // ok for string, not ok for Date
+    return reply.status(200).send({ date: new Date(date).toJSON() });
   },
   'POST /': (req, reply) => {
     if (req.operationPath !== 'POST /') {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -14,7 +14,6 @@ class MyObjectId extends String implements ObjectId {
     return this.id;
   }
 }
-
 export const defaultService: Service<TestSchema> = {
   'GET /': (req, reply) => {
     if (req.operationPath !== 'GET /') {
@@ -29,9 +28,13 @@ export const defaultService: Service<TestSchema> = {
     return reply.status(200).send([{ name: 'user1' }, { id: '1', type: 'TEST' }, { any: 'thing' }]);
   },
   'POST /jsonify': (req, reply) => {
-    const { date } = req.body;
-    date.charAt; // ok for string, not ok for Date
-    return reply.status(200).send({ date: new Date(date).toJSON() });
+    const { date, regexp } = req.body;
+
+    return reply.status(200).send({
+      date: new Date(date),
+      type: typeof date,
+      regexpType: typeof regexp,
+    });
   },
   'POST /': (req, reply) => {
     if (req.operationPath !== 'POST /') {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -32,6 +32,7 @@ export const defaultService: Service<TestSchema> = {
 
     return reply.status(200).send({
       date: new Date(date),
+      dateString: new Date(date).toDateString(),
       type: typeof date,
       regexpType: typeof regexp,
     });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -410,7 +410,7 @@ t.test('it does not interfere with prefixed plugin', async (t) => {
               },
             },
           };
-          app.get('/', { schema }, (req, reply) => {
+          app.get('/', { schema }, (req) => {
             return String(req.routeOptions.schema === schema);
           });
           done();
@@ -431,6 +431,19 @@ t.test('it works with /jsonify', async (t) => {
     method: 'POST',
     payload: { date: new Date(0), regexp: /test/.toString() },
   });
+
   t.equal(res.statusCode, 200);
   t.same(res.json(), { date: new Date(0).toJSON(), type: 'string', regexpType: 'string' });
+});
+t.test('it works with /jsonify 2', async (t) => {
+  const app = await buildApp({ t });
+  const date = new Date(0).toJSON();
+  const res2 = await app.inject({
+    url: '/jsonify',
+    method: 'POST',
+    payload: { date, regexp: '' },
+  });
+  t.equal(res2.statusCode, 200);
+
+  t.same(res2.json(), { date, type: 'string', regexpType: 'string' });
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -433,7 +433,12 @@ t.test('it works with /jsonify', async (t) => {
   });
 
   t.equal(res.statusCode, 200);
-  t.same(res.json(), { date: new Date(0).toJSON(), type: 'string', regexpType: 'string' });
+  t.same(res.json(), {
+    date: new Date(0).toJSON(),
+    dateString: 'Thu Jan 01 1970',
+    type: 'string',
+    regexpType: 'string',
+  });
 });
 t.test('it works with /jsonify 2', async (t) => {
   const app = await buildApp({ t });
@@ -445,5 +450,5 @@ t.test('it works with /jsonify 2', async (t) => {
   });
   t.equal(res2.statusCode, 200);
 
-  t.same(res2.json(), { date, type: 'string', regexpType: 'string' });
+  t.same(res2.json(), { date, dateString: 'Thu Jan 01 1970', type: 'string', regexpType: 'string' });
 });

--- a/test/test_schema.gen.json
+++ b/test/test_schema.gen.json
@@ -8,9 +8,11 @@
         "required": [
           "headers"
         ],
+        "additionalProperties": false,
         "properties": {
           "headers": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "authorization": {
                 "type": "string"
@@ -24,6 +26,7 @@
         "required": [
           "name"
         ],
+        "additionalProperties": false,
         "properties": {
           "name": {
             "type": "string"
@@ -36,6 +39,7 @@
           "id",
           "type"
         ],
+        "additionalProperties": false,
         "properties": {
           "type": {
             "type": "string"
@@ -51,11 +55,16 @@
       },
       "TestObj": {
         "type": "object",
-        "$ref": "test_schema#/properties/Omit__Obj,\"type\"__",
         "required": [
+          "id",
           "type"
         ],
+        "additionalProperties": false,
         "properties": {
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
           "type": {
             "type": "string",
             "const": "TEST"
@@ -102,18 +111,6 @@
             }
           }
         ]
-      },
-      "Omit__Obj,\"type\"__": {
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "id": {
-            "format": "uuid",
-            "type": "string"
-          }
-        }
       }
     },
     "type": "object"
@@ -121,15 +118,16 @@
   "fastify": {
     "GET /": {
       "request": {
-        "$ref": "test_schema#/properties/SharedRequest",
         "type": "object",
         "required": [
           "headers",
           "querystring"
         ],
+        "additionalProperties": false,
         "properties": {
           "querystring": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "getQueryParam": {
                 "type": "boolean"
@@ -142,6 +140,7 @@
               "authorization",
               "getHeader"
             ],
+            "additionalProperties": false,
             "properties": {
               "authorization": {
                 "type": "string"
@@ -198,12 +197,14 @@
         "required": [
           "body"
         ],
+        "additionalProperties": false,
         "properties": {
           "body": {
             "type": "object",
             "required": [
               "user"
             ],
+            "additionalProperties": false,
             "properties": {
               "user": {
                 "$ref": "test_schema#/properties/User"
@@ -219,6 +220,7 @@
             "msg",
             "user"
           ],
+          "additionalProperties": false,
           "properties": {
             "user": {
               "$ref": "test_schema#/properties/User"
@@ -236,16 +238,23 @@
         "required": [
           "body"
         ],
+        "additionalProperties": false,
         "properties": {
           "body": {
             "type": "object",
             "required": [
-              "date"
+              "date",
+              "regexp"
             ],
+            "additionalProperties": false,
             "properties": {
               "date": {
                 "type": "string",
                 "format": "date-time"
+              },
+              "regexp": {
+                "type": "string",
+                "format": "regex"
               }
             }
           }
@@ -255,12 +264,21 @@
         "200": {
           "type": "object",
           "required": [
-            "date"
+            "date",
+            "regexpType",
+            "type"
           ],
+          "additionalProperties": false,
           "properties": {
             "date": {
               "type": "string",
               "format": "date-time"
+            },
+            "type": {
+              "type": "string"
+            },
+            "regexpType": {
+              "type": "string"
             }
           }
         }
@@ -280,6 +298,7 @@
         "required": [
           "params"
         ],
+        "additionalProperties": false,
         "properties": {
           "params": {
             "type": "object",
@@ -287,6 +306,7 @@
               "id",
               "subid"
             ],
+            "additionalProperties": false,
             "properties": {
               "id": {
                 "type": "number"
@@ -308,6 +328,7 @@
           "required": [
             "frame"
           ],
+          "additionalProperties": false,
           "properties": {
             "frame": {
               "$ref": "test_schema#/properties/TestObj"
@@ -322,12 +343,14 @@
         "required": [
           "params"
         ],
+        "additionalProperties": false,
         "properties": {
           "params": {
             "type": "object",
             "required": [
               "castedToNumber"
             ],
+            "additionalProperties": true,
             "properties": {
               "castedToNumber": {
                 "type": "number"
@@ -348,12 +371,14 @@
         "required": [
           "querystring"
         ],
+        "additionalProperties": false,
         "properties": {
           "querystring": {
             "type": "object",
             "required": [
               "match"
             ],
+            "additionalProperties": false,
             "properties": {
               "match": {
                 "type": "string"
@@ -368,6 +393,7 @@
           "required": [
             "value"
           ],
+          "additionalProperties": false,
           "properties": {
             "value": {
               "enum": [
@@ -386,12 +412,14 @@
         "required": [
           "querystring"
         ],
+        "additionalProperties": false,
         "properties": {
           "querystring": {
             "type": "object",
             "required": [
               "reply"
             ],
+            "additionalProperties": false,
             "properties": {
               "reply": {
                 "type": "string"
@@ -406,6 +434,7 @@
           "required": [
             "value"
           ],
+          "additionalProperties": false,
           "properties": {
             "value": {
               "type": "string",
@@ -423,6 +452,7 @@
           "required": [
             "id"
           ],
+          "additionalProperties": false,
           "properties": {
             "id": {
               "type": "string"
@@ -432,5 +462,5 @@
       }
     }
   },
-  "$hash": "1252b062241bb72c9f02a27d8f3c6cee7f3bd8a1e7a8142a5a4b88038790d19f__v1.2.0"
+  "$hash": "38609094e259b0406fb6727e3c67af0ce5bad2bc2e945b8df8762d7f3bdf61c7__v1.2.0"
 }

--- a/test/test_schema.gen.json
+++ b/test/test_schema.gen.json
@@ -265,12 +265,17 @@
           "type": "object",
           "required": [
             "date",
+            "dateString",
             "regexpType",
             "type"
           ],
           "additionalProperties": false,
           "properties": {
             "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "dateString": {
               "type": "string",
               "format": "date-time"
             },
@@ -462,5 +467,5 @@
       }
     }
   },
-  "$hash": "38609094e259b0406fb6727e3c67af0ce5bad2bc2e945b8df8762d7f3bdf61c7__v1.2.0"
+  "$hash": "09d762cb9c53f4338c7374249078c983ab9ddf1a0814f98d7854a4e15f301e7b__v1.2.0"
 }

--- a/test/test_schema.gen.json
+++ b/test/test_schema.gen.json
@@ -230,6 +230,42 @@
         }
       }
     },
+    "POST /jsonify": {
+      "request": {
+        "type": "object",
+        "required": [
+          "body"
+        ],
+        "properties": {
+          "body": {
+            "type": "object",
+            "required": [
+              "date"
+            ],
+            "properties": {
+              "date": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        }
+      },
+      "response": {
+        "200": {
+          "type": "object",
+          "required": [
+            "date"
+          ],
+          "properties": {
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    },
     "GET /empty": {
       "request": {},
       "response": {}
@@ -396,5 +432,5 @@
       }
     }
   },
-  "$hash": "55f23702a95be2a6d63340bde05157e37feed81b4eeb0badfccc120a27d59da5__v1.2.0"
+  "$hash": "1252b062241bb72c9f02a27d8f3c6cee7f3bd8a1e7a8142a5a4b88038790d19f__v1.2.0"
 }

--- a/test/test_schema.ts
+++ b/test/test_schema.ts
@@ -87,7 +87,12 @@ export interface TestSchema extends Schema {
       };
       response: {
         200: {
-          content: { date: Date; type: string; regexpType: string };
+          content: {
+            date: Date;
+            dateString: Date;
+            type: string;
+            regexpType: string;
+          };
         };
       };
     };

--- a/test/test_schema.ts
+++ b/test/test_schema.ts
@@ -70,6 +70,18 @@ export interface TestSchema extends Schema {
         };
       };
     };
+    'POST /jsonify': {
+      request: {
+        body: {
+          date: Date;
+        };
+      };
+      response: {
+        200: {
+          content: { date: Date };
+        };
+      };
+    };
     'GET /empty': {
       response: {
         204: {};

--- a/test/test_schema.ts
+++ b/test/test_schema.ts
@@ -73,12 +73,21 @@ export interface TestSchema extends Schema {
     'POST /jsonify': {
       request: {
         body: {
+          /**
+           * @type string
+           * @format date-time
+           */
           date: Date;
+          /**
+           * @type string
+           * @format regex
+           */
+          regexp: string;
         };
       };
       response: {
         200: {
-          content: { date: Date };
+          content: { date: Date; type: string; regexpType: string };
         };
       };
     };
@@ -115,6 +124,7 @@ export interface TestSchema extends Schema {
     };
     'GET /inferredParams/:id/:castedToNumber': {
       request: {
+        /** @additionalProperties true */
         params: {
           castedToNumber: number;
         };

--- a/test/typed-fastify.test-d.ts
+++ b/test/typed-fastify.test-d.ts
@@ -725,7 +725,7 @@ expectType<Service<Params>>({
 function verifyJsonlike<
   Input,
   Expected extends Jsonlike<Input, DoNotCastToPrimitive>,
-  DoNotCastToPrimitive extends boolean = false,
+  DoNotCastToPrimitive extends 'cast' | 'no-cast',
 >() {}
 
 verifyJsonlike<
@@ -754,7 +754,8 @@ verifyJsonlike<
     B: Invalid<'B is not Json-like'>;
     C: Invalid<'C is not Json-like'>;
     D: Invalid<'D is not Json-like'>;
-  }
+  },
+  'cast'
 >();
 
 verifyJsonlike<
@@ -768,5 +769,5 @@ verifyJsonlike<
     b: number;
     A: Invalid<'A is not Json-like'>;
   },
-  true
+  'no-cast'
 >();

--- a/test/typed-fastify.test-d.ts
+++ b/test/typed-fastify.test-d.ts
@@ -725,7 +725,7 @@ expectType<Service<Params>>({
 function verifyJsonlike<
   Input,
   Expected extends Jsonlike<Input, DoNotCastToPrimitive>,
-  DoNotCastToPrimitive extends 'cast' | 'no-cast',
+  DoNotCastToPrimitive extends 'cast' | 'combine',
 >() {}
 
 verifyJsonlike<
@@ -769,5 +769,5 @@ verifyJsonlike<
     b: number;
     A: Invalid<'A is not Json-like'>;
   },
-  'no-cast'
+  'combine'
 >();


### PR DESCRIPTION
Continuation of #89 

request body is typed as json-like structure, while response body is not fully casted and doesn't cast original types from schema.

@qwelias, it was a nice puzzle! Could you please verify if it meets your expectations, works correctly, and covers all your cases? Thank you.