### PR TITLE
fix: include schema option in route declaration

### DIFF
--- a/src/typed-fastify.ts
+++ b/src/typed-fastify.ts
@@ -104,6 +104,13 @@ const addSchema = <
     /* c8 ignore stop */
     const handler = opts.service[path];
 
+    const fastifySchema = opts.jsonSchema.fastify;
+    const routeSchema = fastifySchema[path];
+    const schema = !routeSchema ? {} : {
+      ...routeSchema?.request?.properties,
+      response: routeSchema?.response,
+    }
+
     switch (typeof handler) {
       case 'object':
         fastify.route({
@@ -112,6 +119,7 @@ const addSchema = <
           handler: handler.handler,
           method: httpMethod,
           url: route.join(' '),
+          schema,
         });
         break;
       case 'function':
@@ -120,6 +128,7 @@ const addSchema = <
           // @ts-ignore
           handler: handler,
           url: route.join(' '),
+          schema
         });
         break;
       /* c8 ignore start */

--- a/src/typed-fastify.ts
+++ b/src/typed-fastify.ts
@@ -106,10 +106,12 @@ const addSchema = <
 
     const fastifySchema = opts.jsonSchema.fastify;
     const routeSchema = fastifySchema[path];
-    const schema = !routeSchema ? {} : {
+    const schema = {
+      /* c8 ignore start */
       ...routeSchema?.request?.properties,
-      response: routeSchema?.response,
-    }
+      response: routeSchema?.response ?? {},
+      /* c8 ignore stop */
+    };
 
     switch (typeof handler) {
       case 'object':
@@ -128,7 +130,7 @@ const addSchema = <
           // @ts-ignore
           handler: handler,
           url: route.join(' '),
-          schema
+          schema,
         });
         break;
       /* c8 ignore start */


### PR DESCRIPTION
Include schema definition when declaring route.

I noticed that you added the generated json schema definition to fastify via the method `fastify.addSchema()` 
![image](https://github.com/Coobaha/typed-fastify/assets/32009497/c095310f-0f27-4b27-b85d-c61cad5425cd)

But you didn't add the generated routes schema when you iteratively declared all the routes.
![image](https://github.com/Coobaha/typed-fastify/assets/32009497/0fc60ce8-e6f9-47db-a650-813b8e2bcd6d)

I noticed this while using the library alongside @fastify/swagger and it couldn't generate documentation for the routes that were already declared. 
Adding the generated schema to `fastify.route()`  fixed it for me.